### PR TITLE
Corrige o problema do não envio do texto com anexo.

### DIFF
--- a/src/components/MessageBubbleWrapper/MessageBubbleWrapper.tsx
+++ b/src/components/MessageBubbleWrapper/MessageBubbleWrapper.tsx
@@ -1,26 +1,38 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from "react";
 
-import { MediaMessage } from '../MediaMessage'
+import { MediaMessage } from "../MediaMessage";
+import { Text } from "@twilio-paste/core";
 
 export const MessageBubbleWrapper = (props: any): JSX.Element => {
-  const [mediaUrl, setMediaUrl] = useState<string | null>(null)
-  const mediaSource = props.message.source.media
+  const [mediaUrl, setMediaUrl] = useState<string | null>(null);
+  const mediaSource = props.message.source.media;
 
   useEffect(() => {
     const fetchMedia = async () => {
       if (mediaSource) {
-        const url = await props.message.source.media.getContentTemporaryUrl()
-        setMediaUrl(url)
+        const url = await props.message.source.media.getContentTemporaryUrl();
+        setMediaUrl(url);
       }
-    }
-    fetchMedia()
-  }, [])
+    };
+    fetchMedia();
+  }, []);
 
   return (
     <>
       {mediaSource && mediaUrl && (
-        <MediaMessage mediaUrl={mediaUrl} mediaType={mediaSource.contentType} />
+        <>
+          <MediaMessage
+            mediaUrl={mediaUrl}
+            mediaType={mediaSource.contentType}
+          />
+          <Text
+            as="span"
+            style={{ fontSize: "0.90rem" }}
+          >
+            {props.message.source.body}
+          </Text>
+        </>
       )}
     </>
-  )
-}
+  );
+};


### PR DESCRIPTION
**Descrição do problema:**
Agentes não conseguem enviar os textos escritos no momento do envio do anexo. O anexo é enviado, mas o texto não. Então é necessário enviar o texto novamente.

**Solução:**
Inclusão de uma tag text no body da mensagem com o seu conteúdo. 
